### PR TITLE
[GCI] Add Login e2e tests for Frontend

### DIFF
--- a/dronesym-frontend/e2e/Login/login.e2e-spec.ts
+++ b/dronesym-frontend/e2e/Login/login.e2e-spec.ts
@@ -1,0 +1,20 @@
+import { LoginPage } from './login.po';
+
+describe('Dronesym Login Page', () => {
+  let page: LoginPage;
+
+  beforeEach(() => {
+    page = new LoginPage();
+  });
+
+  it('Should display Login Form With The title "Login"', () => {
+    page.navigateTo();
+    expect(page.getLoginFormTitle()).toEqual('Login');
+  });
+
+  it('Should Login User', async () => {
+    await page.loginUser();
+    const loggedUrl = await page.getUrl();
+    expect(loggedUrl).toContain('/dashboard');
+  });
+});

--- a/dronesym-frontend/e2e/Login/login.po.ts
+++ b/dronesym-frontend/e2e/Login/login.po.ts
@@ -1,0 +1,25 @@
+import { browser, by, element } from 'protractor';
+
+export class LoginPage {
+  navigateTo() {
+    return browser.get('/login');
+  }
+
+  getLoginFormTitle() {
+    return element(by.className('card-title')).getText();
+  }
+
+  async loginUser() {
+    const usernameInput = element(by.id('username'));
+    const passwordInput = element(by.id('password'));
+    const submitButton = element(by.css('button.btn'));
+
+    await usernameInput.sendKeys('admin');
+    await passwordInput.sendKeys('admin');
+    return submitButton.click();
+  }
+
+  async getUrl() {
+    return await browser.getCurrentUrl();
+  }
+}

--- a/dronesym-frontend/e2e/app.e2e-spec.ts
+++ b/dronesym-frontend/e2e/app.e2e-spec.ts
@@ -7,6 +7,7 @@ describe('dronesym-frontend App', () => {
     page = new DronesymFrontendPage();
   });
 
+  // FIXME: This test is redundant, we should delete it
   it('should display welcome message', () => {
     page.navigateTo();
     expect(page.getParagraphText()).toEqual('Welcome to app!!');


### PR DESCRIPTION
## Fast Summary
This PR adds *End to End* testing for Login Page of the App. For now, I've added these tests:
- [x] Login Form display
- [x] Login test
- [ ] Login failure

Screenshot of passing tests (The welcome message test should be deleted IMO, it is redundant):
![dronesym_tests](https://user-images.githubusercontent.com/25536472/48662990-1c8a1d00-ea8a-11e8-8b9a-ada9b8afeec2.png)